### PR TITLE
Add test for special LBI register override

### DIFF
--- a/libmiemu/datapath/ID.cpp
+++ b/libmiemu/datapath/ID.cpp
@@ -5,10 +5,17 @@ void ID::signals_in(const IFID& ifid, const Controls& ctrl, uint8_t write_reg, u
 	_controls = ctrl;
 	_ifid = ifid;
 
-	const uint8_t read1 = (ifid.instruction >> 4) & 0x000F;
-	const uint8_t read2 = (ctrl.id_controls.reg_position
-		? ifid.instruction >> 0
-		: ifid.instruction >> 8) & 0x000F;
+	uint8_t read1;
+	uint8_t read2;
+	if(!ctrl.id_controls.use_8bit_data) {
+		read1 = (ifid.instruction >> 4) & 0x000F;
+		read2 = (ctrl.id_controls.reg_position
+			? ifid.instruction >> 0
+			: ifid.instruction >> 8) & 0x000F;
+	}
+	else {
+		read1 = read2 = 0;
+	}
 
 	// TODO this signal is redundant
 	const bool write = (write_reg != 0);

--- a/tests/test_id.cpp
+++ b/tests/test_id.cpp
@@ -213,6 +213,28 @@ TEST(ID, WriteDataLBI)
 	EXPECT_EQ(0x007F, id.signals_out().write_data);
 }
 
+TEST(ID, LBIRegisterValues)
+{
+	ID id;
+	IFID ifid;
+	Controller controller;
+
+	// When handling the LBI instruction, The ID stage should emit 0x0000 for
+	// data1 and data2 so the EX stage can add zero to the immediate operand
+	// (of course, this needs the proper commands from the controller).
+	ifid.instruction = inst::lbi(DONTCARE, 0xFF);
+	controller.signals_in(ifid.instruction);
+	Controls ctrl = controller.controls_out();
+
+	// If this isn't handled correctly, the ID stage will read the 0xF register.
+	// So write data there so we can detect that
+	id.signals_in(ifid, ctrl, 0xF, 0xC0DE);
+	id.tick();
+	id.tock();
+	EXPECT_EQ(0, id.signals_out().data1);
+	EXPECT_EQ(0, id.signals_out().data2);
+}
+
 TEST(ID, OutputsChangeOnTick)
 {
 	ID id;


### PR DESCRIPTION
@aharris739 see the test on the first commit fail.  We need the data to be overridden to zero to add zero later.
